### PR TITLE
Support for top-level collections.

### DIFF
--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilder.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilder.java
@@ -27,6 +27,16 @@ public interface ConsumerBuilder<T> {
   <S> ConsumerBuilder<T> useTypeMapping(Class<S> type, PactDslModifier<S> modifier);
 
   /**
+   * Overrides the default behavior for arrays. Per default, the {@link MinArrayLikeModifier} is used. To change the
+   * global behavior use this method. <b>If you want to change the array mapping per field, use
+   * {@link #field(TypedSelector)} and specify a custom field mapping instead.</b>
+   *
+   * @param customArrayModifier The custom implementation of {@link PactDslArrayModifier}.
+   * @return Returns this instance for method chaining.
+   */
+  ConsumerBuilder<T> useArrayMapping(PactDslArrayModifier customArrayModifier);
+
+  /**
    * Selects a field to specify a JSON mapping. Global type mappings added by
    * {@link #useTypeMapping(Class, PactDslModifier)}, {@link #referencing(ConsumerBuilder)} or default type mappings
    * will be overridden by field configurations.
@@ -54,6 +64,15 @@ public interface ConsumerBuilder<T> {
    *         was configured for.
    */
   PactDslJsonBody build(PactDslJsonBody pactDslJsonBody, T sampleData);
+
+  /**
+   * Creates a new {@link PactDslJsonBody} and generates the JSON structure.
+   *
+   * @param sampleData The sample data instance that provides values for each field of the type.
+   * @return Returns a {@link PactDslJsonBody} representing the JSON structure of the type, this {@link ConsumerBuilder}
+   *         was configured for.
+   */
+  PactDslJsonBody build(T sampleData);
 
   /**
    * @return Returns the type this {@link ConsumerBuilder} is using.

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerExpects.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerExpects.java
@@ -3,13 +3,13 @@ package com.remondis.cdc.consumer.pactbuilder;
 /**
  * This is the main entry point for the builder used to configure the JSON structure of a Java Bean used in Pact
  * consumer tests.
- * 
+ *
  * @param <T> The type of object that's JSON structure is to be defined.
  */
 public class ConsumerExpects {
   /**
-   * Specifies the type of Java Bean that is to be defined as a JSON structure.
-   * 
+   * Consumer expects an object structure. Specifies the type of Java Bean that is to be defined as a JSON structure.
+   *
    * @param <T> The type.
    * @param type The type.
    * @return Returns a new {@link ConsumerBuilder} for further configuration.
@@ -17,4 +17,9 @@ public class ConsumerExpects {
   public static <T> ConsumerBuilder<T> type(Class<T> type) {
     return new ConsumerBuilderImpl<T>(type);
   }
+
+  public static <T> TopLevelCollectionDecorator<T> collectionOf(Class<T> type) {
+    return new TopLevelCollectionDecorator<>(type);
+  }
+
 }

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/MinArrayLikeModifier.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/MinArrayLikeModifier.java
@@ -1,0 +1,15 @@
+package com.remondis.cdc.consumer.pactbuilder;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+/**
+ * The default array modifier for the {@link ConsumerBuilder}.
+ */
+public class MinArrayLikeModifier implements PactDslArrayModifier {
+
+  @Override
+  public PactDslJsonBody startArray(PactDslJsonBody pactDslJsonBody, String fieldName) {
+    return pactDslJsonBody.minArrayLike(fieldName, 1);
+  }
+
+}

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/PactDslArrayModifier.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/PactDslArrayModifier.java
@@ -1,0 +1,25 @@
+package com.remondis.cdc.consumer.pactbuilder;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+/**
+ * This interface defines a modifier to build arrays in a {@link PactDslJsonBody}. You can replace the default behaviour
+ * for arrays by implementing your own array modifier an register it to the {@link ConsumerBuilder}.
+ */
+public interface PactDslArrayModifier {
+
+  /**
+   * Starts a new array by calling the respective method on the {@link PactDslJsonBody}.
+   *
+   * @param pactDslJsonBody The {@link PactDslJsonBody} to perform calls on.
+   * @param fieldName The field name of the array.
+   * @return Returns the value from the {@link PactDslJsonBody} call.
+   */
+  public PactDslJsonBody startArray(PactDslJsonBody pactDslJsonBody, String fieldName);
+
+  public default DslPart closeArray(PactDslJsonBody pactDslJsonBody) {
+    return pactDslJsonBody.closeArray();
+  }
+
+}

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/TopLevelCollectionDecorator.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/TopLevelCollectionDecorator.java
@@ -1,0 +1,50 @@
+package com.remondis.cdc.consumer.pactbuilder;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Supplier;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+/**
+ * This is a decorator for {@link ConsumerBuilder} that produces a top-level collection in the resulting JSON structure.
+ * Use {@link ConsumerExpects#collectionOf(Class)} to build a Pact Consumer that expected a top-level array/collection.
+ *
+ * @param <T> The type of object that's JSON structure is to be defined.
+ */
+public class TopLevelCollectionDecorator<T> extends ConsumerBuilderImpl<T> {
+
+  private static final Supplier<PactDslJsonBody> DEFAULT_SUPPLIER = () -> PactDslJsonArray.arrayMinLike(1);
+  private Supplier<PactDslJsonBody> topLevelArraySupplier = DEFAULT_SUPPLIER;
+
+  TopLevelCollectionDecorator(Class<T> type) {
+    super(type);
+  }
+
+  /**
+   * Overrides the default mapping for a top-level Pact Consumer JSON list. Per default
+   * <code>PactDslJsonArray.arrayMinLike(1)</code> is used. To configure another strategy you can specify another
+   * {@link Supplier} that produces a prepared {@link PactDslJsonBody}.
+   *
+   * @param supplier The supplier that always returns a <b>new</b> {@link PactDslJsonBody} prepared to represent an
+   *        array.
+   * @return Returns this {@link ConsumerBuilder} for further configuration.
+   */
+  public ConsumerBuilder<T> useArraySupplier(Supplier<PactDslJsonBody> supplier) {
+    requireNonNull(supplier, "supplier must not be null!");
+    this.topLevelArraySupplier = supplier;
+    return this;
+  }
+
+  @Override
+  public PactDslJsonBody build(T sampleData) {
+    return super.build(topLevelArraySupplier.get(), sampleData);
+  }
+
+  @Override
+  public PactDslJsonBody build(PactDslJsonBody pactDslJsonBody, T sampleData) {
+    return super.build(topLevelArraySupplier.get(), sampleData);
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/customArrayMapping/CustomeArrayMappingTest.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/customArrayMapping/CustomeArrayMappingTest.java
@@ -1,0 +1,27 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.customArrayMapping;
+
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.remondis.cdc.consumer.pactbuilder.ConsumerExpects;
+import com.remondis.cdc.consumer.pactbuilder.TestUtil;
+import com.remondis.resample.Samples;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+public class CustomeArrayMappingTest {
+
+  @Test
+  public void testList() {
+    ListParent listParent = Samples.Default.of(ListParent.class)
+        .newInstance();
+    PactDslJsonBody pactDslJsonBody = ConsumerExpects.type(ListParent.class)
+        .referencing(ConsumerExpects.type(Structure.class))
+        .build(new PactDslJsonBody(), listParent);
+
+    String actualJson = TestUtil.toJson(pactDslJsonBody);
+    JSONAssert.assertEquals("{\"children\":[{\"string\":\"string\"}]}", actualJson, JSONCompareMode.NON_EXTENSIBLE);
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/customArrayMapping/ListParent.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/customArrayMapping/ListParent.java
@@ -1,0 +1,56 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.customArrayMapping;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ListParent {
+  private List<Structure> children = new LinkedList<>();
+
+  public ListParent() {
+    super();
+  }
+
+  public ListParent(List<Structure> children) {
+    super();
+    this.children = children;
+  }
+
+  public List<Structure> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<Structure> children) {
+    this.children = children;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((children == null) ? 0 : children.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ListParent other = (ListParent) obj;
+    if (children == null) {
+      if (other.children != null)
+        return false;
+    } else if (!children.equals(other.children))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "ListParent [children=" + children + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/customArrayMapping/Structure.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/customArrayMapping/Structure.java
@@ -1,0 +1,54 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.customArrayMapping;
+
+public class Structure {
+
+  private String string;
+
+  public Structure(String string) {
+    super();
+    this.string = string;
+  }
+
+  public Structure() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Structure other = (Structure) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "Structure [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/listTest/ListParent.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/listTest/ListParent.java
@@ -1,0 +1,56 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.listTest;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ListParent {
+  private List<Structure> children = new LinkedList<>();
+
+  public ListParent() {
+    super();
+  }
+
+  public ListParent(List<Structure> children) {
+    super();
+    this.children = children;
+  }
+
+  public List<Structure> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<Structure> children) {
+    this.children = children;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((children == null) ? 0 : children.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ListParent other = (ListParent) obj;
+    if (children == null) {
+      if (other.children != null)
+        return false;
+    } else if (!children.equals(other.children))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "ListParent [children=" + children + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/listTest/ListTest.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/listTest/ListTest.java
@@ -1,0 +1,43 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.listTest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.remondis.cdc.consumer.pactbuilder.ConsumerExpects;
+import com.remondis.cdc.consumer.pactbuilder.MinArrayLikeModifier;
+import com.remondis.cdc.consumer.pactbuilder.TestUtil;
+import com.remondis.resample.Samples;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListTest {
+
+  @Spy
+  private MinArrayLikeModifier arrayModifier = new MinArrayLikeModifier();
+
+  @Test
+  public void testList() {
+    ListParent listParent = Samples.Default.of(ListParent.class)
+        .newInstance();
+    PactDslJsonBody pactDslJsonBody = ConsumerExpects.type(ListParent.class)
+        .useArrayMapping(arrayModifier)
+        .referencing(ConsumerExpects.type(Structure.class))
+        .build(new PactDslJsonBody(), listParent);
+
+    String actualJson = TestUtil.toJson(pactDslJsonBody);
+    JSONAssert.assertEquals("{\"children\":[{\"string\":\"string\"}]}", actualJson, JSONCompareMode.NON_EXTENSIBLE);
+
+    verify(arrayModifier, times(1)).startArray(any(), anyString());
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/listTest/Structure.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/listTest/Structure.java
@@ -1,0 +1,54 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.listTest;
+
+public class Structure {
+
+  private String string;
+
+  public Structure(String string) {
+    super();
+    this.string = string;
+  }
+
+  public Structure() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Structure other = (Structure) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "Structure [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/ListParent.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/ListParent.java
@@ -1,0 +1,56 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.topLevelList;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ListParent {
+  private List<Structure> children = new LinkedList<>();
+
+  public ListParent() {
+    super();
+  }
+
+  public ListParent(List<Structure> children) {
+    super();
+    this.children = children;
+  }
+
+  public List<Structure> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<Structure> children) {
+    this.children = children;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((children == null) ? 0 : children.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ListParent other = (ListParent) obj;
+    if (children == null) {
+      if (other.children != null)
+        return false;
+    } else if (!children.equals(other.children))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "ListParent [children=" + children + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/Structure.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/Structure.java
@@ -1,0 +1,54 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.topLevelList;
+
+public class Structure {
+
+  private String string;
+
+  public Structure(String string) {
+    super();
+    this.string = string;
+  }
+
+  public Structure() {
+    super();
+  }
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((string == null) ? 0 : string.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Structure other = (Structure) obj;
+    if (string == null) {
+      if (other.string != null)
+        return false;
+    } else if (!string.equals(other.string))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "Structure [string=" + string + "]";
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/TopLevelListTest.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/TopLevelListTest.java
@@ -39,7 +39,6 @@ public class TopLevelListTest {
             .get());
 
     String actualJson = TestUtil.toJson(pactDslJsonBody);
-    System.out.println(actualJson);
     JSONAssert.assertEquals("{\"children\":[{\"string\":\"string\"}]}", actualJson, JSONCompareMode.NON_EXTENSIBLE);
     verify(supplier, times(1)).get();
   }

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/TopLevelListTest.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/TopLevelListTest.java
@@ -1,0 +1,47 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.topLevelList;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Supplier;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.remondis.cdc.consumer.pactbuilder.ConsumerExpects;
+import com.remondis.cdc.consumer.pactbuilder.TestUtil;
+import com.remondis.resample.Samples;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TopLevelListTest {
+
+  @Spy
+  private Supplier<PactDslJsonBody> supplier = new Supplier<PactDslJsonBody>() {
+
+    @Override
+    public PactDslJsonBody get() {
+      return PactDslJsonArray.arrayEachLike(1);
+    }
+  };
+
+  @Test
+  public void shouldCreateTopLevelList() throws Exception {
+    PactDslJsonBody pactDslJsonBody = ConsumerExpects.collectionOf(ListParent.class)
+        .useArraySupplier(supplier)
+        .build(Samples.Default.of(ListParent.class)
+            .get());
+
+    String actualJson = TestUtil.toJson(pactDslJsonBody);
+    System.out.println(actualJson);
+    JSONAssert.assertEquals("{\"children\":[{\"string\":\"string\"}]}", actualJson, JSONCompareMode.NON_EXTENSIBLE);
+    verify(supplier, times(1)).get();
+  }
+
+}


### PR DESCRIPTION
Now it's possible to create top-level collections in the Pact via
```
ConsumerExpects.collectionOf(<LIST_ELEMENT_TYPE_HERE>)
        .useArraySupplier(supplier) // Optionally, customize the PactDslJsonArray structure
        .build(<LIST_ELEMENT_SAMPLE_HERE>);
``` 