### PR TITLE
Wrong representation of top level list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis.cdc</groupId>
     <artifactId>pact-consumer-builder</artifactId>
-    <version>0.0.4</version>
+    <version>0.1.0</version>
     <description>A builder that generates JSON expectations for PACT consumer tests.</description>
     <url>https://github.com/remondis-it/pact-consumer-builder</url>
     <scm>

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerExpects.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerExpects.java
@@ -19,7 +19,7 @@ public class ConsumerExpects {
   }
 
   public static <T> TopLevelCollectionDecorator<T> collectionOf(Class<T> type) {
-    return new TopLevelCollectionDecorator<>(type);
+    return new TopLevelCollectionDecorator<>();
   }
 
 }

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/TopLevelCollectionDecorator.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/TopLevelCollectionDecorator.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Supplier;
 
+import au.com.dius.pact.consumer.dsl.DslPart;
 import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 
@@ -13,14 +14,12 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
  *
  * @param <T> The type of object that's JSON structure is to be defined.
  */
-public class TopLevelCollectionDecorator<T> extends ConsumerBuilderImpl<T> {
+public class TopLevelCollectionDecorator<T> {
 
   private static final Supplier<PactDslJsonBody> DEFAULT_SUPPLIER = () -> PactDslJsonArray.arrayMinLike(1);
   private Supplier<PactDslJsonBody> topLevelArraySupplier = DEFAULT_SUPPLIER;
 
-  TopLevelCollectionDecorator(Class<T> type) {
-    super(type);
-  }
+  private ConsumerBuilder<T> arrayContentBuilder;
 
   /**
    * Overrides the default mapping for a top-level Pact Consumer JSON list. Per default
@@ -31,20 +30,35 @@ public class TopLevelCollectionDecorator<T> extends ConsumerBuilderImpl<T> {
    *        array.
    * @return Returns this {@link ConsumerBuilder} for further configuration.
    */
-  public ConsumerBuilder<T> useArraySupplier(Supplier<PactDslJsonBody> supplier) {
+  public TopLevelCollectionDecorator<T> useArraySupplier(Supplier<PactDslJsonBody> supplier) {
     requireNonNull(supplier, "supplier must not be null!");
     this.topLevelArraySupplier = supplier;
     return this;
   }
 
-  @Override
-  public PactDslJsonBody build(T sampleData) {
-    return super.build(topLevelArraySupplier.get(), sampleData);
+  /**
+   * Specifies the {@link ConsumerBuilder} for the array content.
+   *
+   * @param consumerBuilder The consumer builder for the array content.
+   * @return Returns this instance for further configuration
+   */
+  public TopLevelCollectionDecorator<T> arrayContent(ConsumerBuilder<T> consumerBuilder) {
+    requireNonNull(consumerBuilder, "suppconsumerBuilderlier must not be null!");
+    this.arrayContentBuilder = consumerBuilder;
+    return this;
   }
 
-  @Override
-  public PactDslJsonBody build(PactDslJsonBody pactDslJsonBody, T sampleData) {
-    return super.build(topLevelArraySupplier.get(), sampleData);
+  /**
+   * Builds the JSON structure with a top level list.
+   *
+   * @param sampleData The sample data for an example array item.
+   * @return Returns the {@link PactDslJsonArray}.
+   */
+  public PactDslJsonArray build(T sampleData) {
+    PactDslJsonBody pactDslJsonBody = topLevelArraySupplier.get();
+    PactDslJsonBody jsonBody = arrayContentBuilder.build(pactDslJsonBody, sampleData);
+    DslPart array = jsonBody.close();
+    return (PactDslJsonArray) array;
   }
 
 }

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/TestUtil.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/TestUtil.java
@@ -5,6 +5,7 @@ import java.io.StringWriter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 
 public class TestUtil {
@@ -32,7 +33,7 @@ public class TestUtil {
 
   /**
    * Converts the {@link PactDslJsonBody} to the specified type.
-   * 
+   *
    * @param <T> The target type to convert to.
    * @param body The {@link PactDslJsonBody} describing the JSON structure of the target type.
    * @param type The target type to convert to.
@@ -48,11 +49,11 @@ public class TestUtil {
 
   /**
    * Converts the specified object to a JSON object.
-   * 
+   *
    * @param object The object to convert.
    * @return Return the JSON as {@link String}.
    * @throws JsonProcessingException
-   * 
+   *
    */
   public static String toJson(Object object) throws JsonProcessingException {
     return JsonHelper.toJson(object);
@@ -60,10 +61,26 @@ public class TestUtil {
 
   /**
    * Converts the specified {@link PactDslJsonBody} to a JSON object.
-   * 
+   *
    * @param body The {@link PactDslJsonBody} describing the JSON structure.
    * @return Return the JSON as {@link String}.
-   * 
+   *
+   */
+  public static String toJson(PactDslJsonArray array) {
+    StringWriter libOutputWriter = new StringWriter();
+    ((org.json.JSONArray) array.getBody()).write(libOutputWriter);
+
+    String jsonString = libOutputWriter.getBuffer()
+        .toString();
+    return jsonString;
+  }
+
+  /**
+   * Converts the specified {@link PactDslJsonBody} to a JSON object.
+   *
+   * @param body The {@link PactDslJsonBody} describing the JSON structure.
+   * @return Return the JSON as {@link String}.
+   *
    */
   public static String toJson(PactDslJsonBody body) {
     StringWriter libOutputWriter = new StringWriter();
@@ -78,7 +95,7 @@ public class TestUtil {
    * Compares the specified expected object with the result from converting a {@link PactDslJsonBody} and expects, that
    * the structures are equal. If so, this method returns. If any differences occur or the conversion fails due to
    * structural differences, this method throws an {@link AssertionError} and prints the JSON differences to sys/out.
-   * 
+   *
    * @param <T> The target type
    * @param expectedObject The expected object
    * @param result The actual result from converting a {@link PactDslJsonBody}.

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/TopLevelListTest.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/topLevelList/TopLevelListTest.java
@@ -33,13 +33,14 @@ public class TopLevelListTest {
 
   @Test
   public void shouldCreateTopLevelList() throws Exception {
-    PactDslJsonBody pactDslJsonBody = ConsumerExpects.collectionOf(ListParent.class)
+    PactDslJsonArray pactDslJsonArray = ConsumerExpects.collectionOf(ListParent.class)
         .useArraySupplier(supplier)
+        .arrayContent(ConsumerExpects.type(ListParent.class))
         .build(Samples.Default.of(ListParent.class)
             .get());
 
-    String actualJson = TestUtil.toJson(pactDslJsonBody);
-    JSONAssert.assertEquals("{\"children\":[{\"string\":\"string\"}]}", actualJson, JSONCompareMode.NON_EXTENSIBLE);
+    String actualJson = TestUtil.toJson(pactDslJsonArray);
+    JSONAssert.assertEquals("[{\"children\":[{\"string\":\"string\"}]}]", actualJson, JSONCompareMode.NON_EXTENSIBLE);
     verify(supplier, times(1)).get();
   }
 


### PR DESCRIPTION
- The top level list feature produces a wrong json structure.
- Fixed by refactoring the TopLevelCollectionDecorator
- Types changes to PactDslJsonArray
- Changes are not backwards compatible:
  - Target version: 0.1.0