### PR TITLE
Added "ignoreMissingValues" feature to ConsumerBuilder

### DIFF
--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilder.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilder.java
@@ -79,4 +79,10 @@ public interface ConsumerBuilder<T> {
    */
   Class<T> getType();
 
+  /**
+   * When building the Pact, don't fail on a null value but just ignore the field instead.
+   *
+   * @return Returns this instance for method chaining.
+   */
+  ConsumerBuilder<T> ignoreMissingValues();
 }

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilderException.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilderException.java
@@ -7,10 +7,7 @@ import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
  */
 public class ConsumerBuilderException extends RuntimeException {
 
-  /**
-   * 
-   */
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2787755594910807663L;
 
   public ConsumerBuilderException() {
   }

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilderImpl.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilderImpl.java
@@ -269,7 +269,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
       try {
         Object value = readOrFail(pd, sampleValue);
         return modifier.apply(pactDslJsonBody, value);
-      } catch (ConsumerBuilderException e) {
+      } catch (NoSampleValueException e) {
         if (ignoreMissingValues) {
           return pactDslJsonBody;
         } else {
@@ -371,7 +371,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
       throw ReflectionException.invocationFailed(property, e);
     }
     if (isNull(returnValue)) {
-      throw new ConsumerBuilderException(
+      throw new NoSampleValueException(
           "A property of the specified sample data object was null. The following get method returned null: "
               + readMethod.toGenericString());
     }

--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/NoSampleValueException.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/NoSampleValueException.java
@@ -1,0 +1,32 @@
+package com.remondis.cdc.consumer.pactbuilder;
+
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+/**
+ * Thrown when no sample value was found while building the {@link PactDslJsonBody}.
+ */
+public class NoSampleValueException extends ConsumerBuilderException {
+
+  private static final long serialVersionUID = 7171434853043392753L;
+
+  public NoSampleValueException() {
+  }
+
+  public NoSampleValueException(String message) {
+    super(message);
+  }
+
+  public NoSampleValueException(Throwable cause) {
+    super(cause);
+  }
+
+  public NoSampleValueException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public NoSampleValueException(String message, Throwable cause, boolean enableSuppression,
+      boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/ConsumerBuilderImplTest.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/ConsumerBuilderImplTest.java
@@ -1,0 +1,79 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.ignoremissingvalues;
+
+import au.com.dius.pact.consumer.ConsumerPactBuilder;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.consumer.dsl.PactDslResponse;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.model.RequestResponsePact;
+import au.com.dius.pact.model.matchingrules.MatchingRules;
+import com.remondis.cdc.consumer.pactbuilder.ConsumerBuilderException;
+import com.remondis.cdc.consumer.pactbuilder.ConsumerExpects;
+import com.remondis.cdc.consumer.pactbuilder.TestUtil;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class ConsumerBuilderImplTest {
+
+  /**
+   * Original behavior, just fail when a given field has a null value
+   */
+  @Test
+  public void shouldFailOnMissingValues() {
+    // Given a Structure instance with one field value not being filled in
+    Structure instance = new Structure();
+    instance.setField1(new SomeField("value1"));
+    instance.setField2(null);
+    // When we build a RequestResponsePact with the given instance
+    // Then the field with the missing value won't be included in the Pact and we should get an exception...
+    try {
+      ConsumerExpects.type(Structure.class)
+          .build(instance);
+      fail("Expected a ConsumerBuilderException because of a missing value");
+    } catch (ConsumerBuilderException e) {
+      assertThat(e.getMessage()).contains("A property of the specified sample data object was null");
+    }
+  }
+
+  /**
+   * New behavior when using "ignoreMissingValues": don't include the empty field in the Pact.
+   */
+  @Test
+  public void shouldIgnoreMissingValuesInsteadOfFailing() {
+    // Given a Structure instance with one field value not being filled in
+    Structure instance = new Structure();
+    instance.setField1(new SomeField("value1"));
+    instance.setField2(null);
+    // When we build a RequestResponsePact with the given instance
+    PactDslJsonBody pactDslJsonBody = ConsumerExpects.type(Structure.class)
+        .ignoreMissingValues()
+        .build(instance);
+    // Then the field with the missing value shouldn't be included in the Pact
+    PactDslWithProvider builder = new PactDslWithProvider(new ConsumerPactBuilder("consumer"), "provider");
+    String actualJson = TestUtil.toJson(pactDslJsonBody);
+    JSONAssert.assertEquals("{\"field1\":{\"field\":\"value1\"}}", actualJson, JSONCompareMode.NON_EXTENSIBLE);
+    // And we shouldn't get an exception...
+    PactDslResponse dslResponse = builder.given("GET request")
+        .uponReceiving("GET request")
+        .path("/structure/1")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .body(pactDslJsonBody);
+    RequestResponsePact pact = dslResponse.toPact();
+    // Only field 1 should be included in the matching rules for body
+    MatchingRules responseMatchingRules = Objects.requireNonNull(pact.getInteractions()
+        .get(0)
+        .getResponse()
+        .getMatchingRules());
+    assertThat(responseMatchingRules.rulesForCategory("body")
+        .getMatchingRules()
+        .size()).isEqualTo(1);
+  }
+
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/SomeField.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/SomeField.java
@@ -1,0 +1,22 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.ignoremissingvalues;
+
+public class SomeField {
+
+  private String field;
+
+  public SomeField() {
+    // default constructor, required for ConsumerBuilder...
+  }
+
+  public SomeField(String field) {
+    this.field = field;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public void setField(String field) {
+    this.field = field;
+  }
+}

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/Structure.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/Structure.java
@@ -1,0 +1,24 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.ignoremissingvalues;
+
+public class Structure {
+
+  private SomeField field1;
+
+  private SomeField field2;
+
+  public SomeField getField1() {
+    return field1;
+  }
+
+  public void setField1(SomeField field1) {
+    this.field1 = field1;
+  }
+
+  public SomeField getField2() {
+    return field2;
+  }
+
+  public void setField2(SomeField field2) {
+    this.field2 = field2;
+  }
+}


### PR DESCRIPTION
Added "ignoreMissingValues" feature to ConsumerBuilder in order to exclude fields without a value instead of failing to build a pact. This is useful when the consumer DTO contains more fields than the provider actually provides. Otherwise the consumer DTO can only have a subset of the provider's DTO.