### PR TITLE
Added "enforcePropertyNamingConvention" feature

### DIFF
--- a/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilder.java
+++ b/src/main/java/com/remondis/cdc/consumer/pactbuilder/ConsumerBuilder.java
@@ -85,4 +85,11 @@ public interface ConsumerBuilder<T> {
    * @return Returns this instance for method chaining.
    */
   ConsumerBuilder<T> ignoreMissingValues();
+
+  /**
+   * Enforce a correct property naming convention. This will make sure properties don't start with uppercase characters.
+   *
+   * @return Returns this instance for method chaining.
+   */
+  ConsumerBuilder<T> enforcePropertyNamingConvention();
 }

--- a/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/CaseFieldObject.java
+++ b/src/test/java/com/remondis/cdc/consumer/pactbuilder/buildertests/ignoremissingvalues/CaseFieldObject.java
@@ -1,0 +1,51 @@
+package com.remondis.cdc.consumer.pactbuilder.buildertests.ignoremissingvalues;
+
+import java.io.Serializable;
+
+/**
+ * When working against generated code libraries,
+ * it's not always possible to enforce the common naming conventions for fieldnames.
+ * This class is used as a (contrived) example for our tests.
+ */
+public class CaseFieldObject implements Serializable {
+
+  private String ABCFieldOne;
+
+  private String abcFieldTwo;
+
+  private String ABcFieldThree;
+
+  public CaseFieldObject() {
+
+  }
+
+  public CaseFieldObject(String abcFieldOne, String abcFieldTwo, String aBcFieldThree) {
+    this.ABCFieldOne = abcFieldOne;
+    this.abcFieldTwo = abcFieldTwo;
+    this.ABcFieldThree = aBcFieldThree;
+  }
+
+  public String getABCFieldOne() {
+    return ABCFieldOne;
+  }
+
+  public void setABCFieldOne(String ABCFieldOne) {
+    this.ABCFieldOne = ABCFieldOne;
+  }
+
+  public String getAbcFieldTwo() {
+    return abcFieldTwo;
+  }
+
+  public void setAbcFieldTwo(String abcFieldTwo) {
+    this.abcFieldTwo = abcFieldTwo;
+  }
+
+  public String getABcFieldThree() {
+    return ABcFieldThree;
+  }
+
+  public void setABcFieldThree(String ABcFieldThree) {
+    this.ABcFieldThree = ABcFieldThree;
+  }
+}


### PR DESCRIPTION
Added "enforcePropertyNamingConvention" feature, so field names will match proper Java naming conventions (start with lowercase)